### PR TITLE
Fixed GitHub issues #3 and #4, unused visited param on ToDictionaryTree and ToExpandoObject

### DIFF
--- a/Jcd.Reflection.Tests/ReflectionExtensionsTests.cs
+++ b/Jcd.Reflection.Tests/ReflectionExtensionsTests.cs
@@ -344,7 +344,7 @@ namespace Jcd.Reflection.Tests
       }
 
       [Fact]
-      public void ToDictionaryTree_Returns_A_String_Object_Dictionary_Tree_Of_The_Object()
+      public void ToDictionaryTree_And_ToExpando_Object_Perform_A_Compatible_RoundTrip()
       {
          var a = new TestClassA();
 
@@ -353,6 +353,22 @@ namespace Jcd.Reflection.Tests
          Assert.Equal(ado,aeo);
       }
 
+      [Fact]
+      public void ToDictionaryTree_Returns_A_String_Object_Dictionary_Tree_Of_The_Object_Without_The_PreVisited_Items()
+      {
+         //TODO: This is a bit of a hack, but it works. 
+         //      Add more in depth tests later. 
+         var a = new TestClassA();
+         var visited = new HashSet<object>();
+         visited.Add(a);
+         dynamic aeo=a.ToExpandoObject(visited);
+         var ado = a.ToDictionaryTree(visited);
+         Assert.Equal(ado,aeo);
+         // we expect null because the root was marked as visited
+         Assert.Null(ado);
+         Assert.Null(aeo);
+      }
+      
       [Fact]
       public void IsScalar_When_Given_DataType_of_Type_Returns_True()
       {

--- a/Jcd.Reflection/ExpandoObjectExtensions.cs
+++ b/Jcd.Reflection/ExpandoObjectExtensions.cs
@@ -29,7 +29,10 @@ namespace Jcd.Reflection
                                                                    Func<string, string> keyRenamingStrategy = null,
                                                                    Func<string, object, bool> valueRetentionStrategy = null)
         {
-            return (IDictionary<string, object>)self.ToDictionaryTree<Dictionary<string, object>>(keyRenamingStrategy:keyRenamingStrategy, valueRetentionStrategy:valueRetentionStrategy);
+            return (IDictionary<string, object>)self.ToDictionaryTree<Dictionary<string, object>>(
+                visited,
+                keyRenamingStrategy,
+                valueRetentionStrategy);
         }
 
         /// <summary>
@@ -107,7 +110,10 @@ namespace Jcd.Reflection
         /// <param name="valueRetentionStrategy"></param>
         /// <typeparam name="TNode"></typeparam>
         /// <returns></returns>
-        private static dynamic ToDictionaryTree<TNode>(this object self, HashSet<object> visited = null, Func<string, string> keyRenamingStrategy = null, Func<string, object, bool> valueRetentionStrategy = null)
+        private static dynamic ToDictionaryTree<TNode>(this object self, 
+                                                       HashSet<object> visited = null, 
+                                                       Func<string, string> keyRenamingStrategy = null, 
+                                                       Func<string, object, bool> valueRetentionStrategy = null)
             where TNode : IDictionary<string, object>, new()
         {
             var root = default(TNode);

--- a/Jcd.Reflection/Jcd.Reflection.csproj
+++ b/Jcd.Reflection/Jcd.Reflection.csproj
@@ -16,7 +16,7 @@
         <FileVersion>1.0.2</FileVersion>
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <PackageIconUrl>https://s.gravatar.com/avatar/c7e8df18f543ea857ac93660a190df98?s=320</PackageIconUrl>
-        <PackageReleaseNotes>Upgraded Jcd.Validations to 1.0.8</PackageReleaseNotes>
+        <PackageReleaseNotes>Fixed GitHub issues #3 and #4 (unused params in ToExpandoObject and ToDictionaryTree)</PackageReleaseNotes>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/docs/Jcd.Reflection.xml
+++ b/docs/Jcd.Reflection.xml
@@ -116,7 +116,6 @@
             </summary>
             <param name="items"></param>
             <param name="item"></param>
-            <param name="skip"></param>
             <returns></returns>
         </member>
         <member name="M:Jcd.Reflection.ExpandoObjectExtensions.ToNameValuePairs(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.Reflection.PropertyInfo,System.Object}})">
@@ -132,7 +131,6 @@
             </summary>
             <param name="items"></param>
             <param name="item"></param>
-            <param name="skip"></param>
             <returns></returns>
         </member>
         <member name="M:Jcd.Reflection.ExpandoObjectExtensions.ToNameValuePairs(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.Reflection.FieldInfo,System.Object}})">


### PR DESCRIPTION
* ToDictionaryTree and ToExpandoObject are now both using  `HashSet<T>` visited to determine which nodes to convert. 
* Added a unit test that covers both

Note: Passing in the root object in visited results in a `null`. This is expected behavior, by definition.